### PR TITLE
fix: add support for newer docker image layout

### DIFF
--- a/docker/util/config_stripper.py
+++ b/docker/util/config_stripper.py
@@ -26,20 +26,25 @@ import tarfile
 import tempfile
 import threading
 
-_TIMESTAMP = '1970-01-01T00:00:00Z'
+_TIMESTAMP = "1970-01-01T00:00:00Z"
 
-WHITELISTED_PREFIXES = ['sha256:', 'manifest', 'repositories']
+WHITELISTED_PREFIXES = ["sha256:", "manifest", "repositories"]
+IGNORED_PREFIXES = "blobs/sha256/sha256:"
 
 _BUF_SIZE = 4096
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--in_tar_path', type=str,
-                        help='Path to docker save tarball',
-                        required=True)
-    parser.add_argument('--out_tar_path', type=str,
-                        help='Path to output stripped tarball',
-                        required=True)
+    parser.add_argument(
+        "--in_tar_path", type=str, help="Path to docker save tarball", required=True
+    )
+    parser.add_argument(
+        "--out_tar_path",
+        type=str,
+        help="Path to output stripped tarball",
+        required=True,
+    )
     args = parser.parse_args()
 
     os.environ["PYTHONIOENCODING"] = "utf-8"
@@ -52,11 +57,15 @@ def strip_tar(input, output):
     # We need to take care to keep the files sorted.
 
     tempdir = tempfile.mkdtemp()
-    with tarfile.open(name=input, mode='r') as it:
-        it.extractall(tempdir)
 
-    mf_path = os.path.join(tempdir, 'manifest.json')
-    with open(mf_path, 'r') as mf:
+    with tarfile.open(name=input, mode="r") as it:
+        if hasattr(tarfile, "data_filter"):
+            it.extractall(path=tempdir, filter="data")
+        else:
+            it.extractall(path=tempdir)
+
+    mf_path = os.path.join(tempdir, "manifest.json")
+    with open(mf_path, "r") as mf:
         manifest = json.load(mf)
     for image in manifest:
         # Scrape each layer for any timestamps
@@ -69,41 +78,48 @@ def strip_tar(input, output):
         # through these layers in top to bottom order, it may encounter a layer
         # that symlinks to a lower layer that hasn't been extracted yet. Just
         # reversing the iteration order avoids this problem.
-        for layer in reversed(image['Layers']):
-          (new_layer_name, new_diff_id) = strip_layer(os.path.join(tempdir, layer))
-
-          new_layers.append(new_layer_name)
-          new_diff_ids.append(new_diff_id)
+        for layer in reversed(image["Layers"]):
+            (new_layer_name, new_diff_id) = strip_layer(
+                os.path.join(tempdir, layer), tempdir
+            )
+            new_layers.append(new_layer_name)
+            new_diff_ids.append(new_diff_id)
         # Reverse the layer order to go back to the topmost layer to bottom as
         # required by the Docker manifest format.
         new_layers = [l for l in reversed(new_layers)]
         new_diff_ids = [d for d in reversed(new_diff_ids)]
 
         # Change the manifest to reflect the new layer name
-        image['Layers'] = new_layers
-
-        config = image['Config']
-        cfg_path = os.path.join(tempdir, config)
-        new_cfg_path = strip_config(cfg_path, new_diff_ids)
+        image["Layers"] = new_layers
+        config = image["Config"]
+        new_cfg_path = strip_config(
+            os.path.join(tempdir, config), tempdir, new_diff_ids
+        )
 
         # Update the name of the config in the metadata object
         # to match it's new digest.
-        image['Config'] = new_cfg_path
+        image["Config"] = new_cfg_path
+
+        # removed unsupported oci key that now contains invalid sha256 keys and additional data
+        if "LayerSources" in image:
+            del image["LayerSources"]
 
     # Rewrite the manifest with the new config names.
-    with open(mf_path, 'w') as f:
+    with open(mf_path, "w") as f:
         json.dump(manifest, f, sort_keys=True)
 
     # Collect the files before adding, so we can sort them.
     files_to_add = []
     for root, _, files in os.walk(tempdir):
         for f in files:
-            if os.path.basename(f).startswith(tuple(WHITELISTED_PREFIXES)):
+            if os.path.basename(f).startswith(
+                tuple(WHITELISTED_PREFIXES)
+            ):  # and not (IGNORED_PREFIXES in os.path.join(root,f)):
                 name = os.path.join(root, f)
-                os.utime(name, (0,0))
+                os.utime(name, (0, 0))
                 files_to_add.append(name)
 
-    with tarfile.open(name=output, mode='w') as ot:
+    with tarfile.open(name=output, mode="w") as ot:
         for f in sorted(files_to_add):
             # Strip the tempdir path
             arcname = os.path.relpath(f, tempdir)
@@ -112,10 +128,12 @@ def strip_tar(input, output):
     shutil.rmtree(tempdir)
     return 0
 
-def strip_layer(path):
+
+def strip_layer(path, base_path):
     # The original layer tar is of the form <random string>/layer.tar, the
     # working directory is one level up from where layer.tar is.
-    original_dir = os.path.normpath(os.path.join(os.path.dirname(path), '..'))
+
+    original_dir = os.path.normpath(os.path.join(os.path.dirname(path), ".."))
 
     # Write compressed tar to a temporary name. We'll rename it to the correct
     # name after we compute the hash.
@@ -131,19 +149,22 @@ def strip_layer(path):
     # This function takes special care to never store the full tar file or
     # gzip'd tar file in memory. Images can be quite large.
     gzip_process = subprocess.Popen(
-        ['gzip', '-nf'],
+        ["gzip", "-nf"],
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+        stderr=subprocess.PIPE,
+    )
 
     # Read the gzip'd output and accumulate the sha hash, and save the
     # compressed copy under the new name.
     gzip_stdout_exc = []
+
     def do_gzip_stdout():
         try:
             while True:
                 buf = gzip_process.stdout.read(_BUF_SIZE)
-                if not buf: break
+                if not buf:
+                    break
                 compressed_sha.update(buf)
                 gz_out.write(buf)
         except Exception as e:
@@ -151,6 +172,7 @@ def strip_layer(path):
 
     # Read the gzip stderr for error reporting.
     gzip_stderr_buf = io.BytesIO()
+
     def do_gzip_stderr():
         # Don't bother incrementally reading stderr.
         gzip_stderr_buf.write(gzip_process.stderr.read())
@@ -166,13 +188,13 @@ def strip_layer(path):
         # If it's a file, add its content to the running buffer
         # Add it to the new gzip'd tar.
         with tempfile.TemporaryFile() as t:
-            with tarfile.open(name=path, mode='r') as it:
-                with tarfile.open(fileobj=t, encoding='utf-8', mode='w') as ot:
+            with tarfile.open(name=path, mode="r") as it:
+                with tarfile.open(fileobj=t, encoding="utf-8", mode="w") as ot:
                     for tarinfo in it:
                         # Use a deterministic mtime that doesn't confuse other
                         # programs,  e.g. Python.  Also see
                         # https://github.com/bazelbuild/bazel/issues/1299
-                        tarinfo.mtime = 946684800 # 2000-01-01 00:00:00.000 UTC
+                        tarinfo.mtime = 946684800  # 2000-01-01 00:00:00.000 UTC
                         if tarinfo.isfile():
                             f = it.extractfile(tarinfo)
                             ot.addfile(tarinfo, f)
@@ -184,63 +206,78 @@ def strip_layer(path):
             t.seek(0)
             while True:
                 buf = t.read(_BUF_SIZE)
-                if not buf: break
+                if not buf:
+                    break
                 uncompressed_sha.update(buf)
                 gzip_process.stdin.write(buf)
     finally:
-        gzip_process.stdin.close() # Causes gzip to terminate.
-        gzip_stdout.join() # Terminates after gzip closes stdout.
-        gzip_stderr.join() # Terminates after gzip closes stderr.
-        gzip_process.wait() # gzip terminated by now.
+        gzip_process.stdin.close()  # Causes gzip to terminate.
+        gzip_stdout.join()  # Terminates after gzip closes stdout.
+        gzip_stderr.join()  # Terminates after gzip closes stderr.
+        gzip_process.wait()  # gzip terminated by now.
 
     # Check if any of our threads or processes failed.
     if gzip_stdout_exc:
         raise gzip_stdout_exc[0]
     if gzip_process.returncode != 0:
         raise RuntimeError(
-                'Failed to gzip stripped layer %s. '
-                'gzip exited with status %d: %s',
-                path, gzip_process.returncode, gzip_stderr_buf.getvalue())
+            "Failed to gzip stripped layer %s. " "gzip exited with status %d: %s",
+            path,
+            gzip_process.returncode,
+            gzip_stderr_buf.getvalue(),
+        )
 
     # Create the new diff_id for the config
-    diffid = 'sha256:%s' % uncompressed_sha.hexdigest()
-
+    diffid = "sha256:%s" % uncompressed_sha.hexdigest()
     # Rename into correct location now that we know the hash.
-    new_name = 'sha256:%s' % compressed_sha.hexdigest()
-    os.rename(gz_out.name, os.path.join(original_dir, new_name))
+    new_name = os.path.join(
+        original_dir.removeprefix(base_path).removeprefix("/"),
+        "sha256:%s" % compressed_sha.hexdigest(),
+    )
+    os.rename(gz_out.name, os.path.join(base_path, new_name))
 
-    shutil.rmtree(os.path.dirname(path))
+    # delete there referenced file layer
+    # only delete the directory if there is 1 file in the list
+    # that would be the correct way
+    # however, we take a short-cut and test for layer.tar instead
+    if path.endswith("layer.tar"):
+        shutil.rmtree(os.path.dirname(path))
+    else:
+        os.remove(path)
     return (new_name, diffid)
 
 
-def strip_config(path, new_diff_ids):
-    with open(path, 'r') as f:
+def strip_config(path, base_path, new_diff_ids):
+    with open(path, "r") as f:
         config = json.load(f)
-    config['created'] = _TIMESTAMP
-    config['rootfs']['diff_ids'] = new_diff_ids
+    config["created"] = _TIMESTAMP
+    config["rootfs"]["diff_ids"] = new_diff_ids
 
     # Base container info is not required and changes every build, so delete it.
-    if 'container' in config:
-      del config['container']
-    if ('config' in config and
-        'Hostname' in config['config']):
-      del config['config']['Hostname']
-    if ('container_config' in config and
-        'Hostname' in config['container_config']):
-      del config['container_config']['Hostname']
-    if 'docker_version' in config:
-      del config['docker_version']
-    for entry in config['history']:
-        entry['created'] = _TIMESTAMP
+    if "container" in config:
+        del config["container"]
+    if "config" in config and "Hostname" in config["config"]:
+        del config["config"]["Hostname"]
+    if "container_config" in config and "Hostname" in config["container_config"]:
+        del config["container_config"]["Hostname"]
+    if "docker_version" in config:
+        del config["docker_version"]
+    for entry in config["history"]:
+        entry["created"] = _TIMESTAMP
 
     config_str = json.dumps(config, sort_keys=True)
-    with open(path, 'w') as f:
+    with open(path, "w") as f:
         f.write(config_str)
 
     # Calculate the new file path
     sha = hashlib.sha256(config_str.encode("utf-8")).hexdigest()
-    new_path = 'sha256:%s' % sha
-    os.rename(path, os.path.join(os.path.dirname(path), new_path))
+    new_path = os.path.join(
+        os.path.dirname(path).removeprefix(base_path).removeprefix("/"),
+        "sha256:%s" % sha,
+    )
+
+    os.rename(path, os.path.join(base_path, new_path))
+
     return new_path
 
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## What is the current behavior?

Building [formatjs](github.com/formatjs/formatjs) fails as the layout of the tar image layers in the saved docker image has changed and the current behaviour removes the directory that contains multiple blob files as shown in the error message below.

```bazel run //packages/intl-datetimeformat:generated_tz_data --spawn_strategy=processwrapper-sandbox --sandbox_debug
INFO: Invocation ID: 42c21fcd-5f66-43fa-8962-02a93f9c6d8e
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/42c21fcd-5f66-43fa-8962-02a93f9c6d8e
INFO: Analyzed target //packages/intl-datetimeformat:generated_tz_data (1 packages loaded, 867 targets configured).
INFO: Found 1 target...
INFO: From Action packages/intl-datetimeformat/build_essential_pkgs.tar:
Loaded image: bazel/image:image
55a31f9880f7f987cb116f8f354bbd37c3520909d6276f2bb9bd301f1bff8846
INFO: From ExtractImageId packages/intl-datetimeformat/ubuntu_build_essential_image.tar.unstripped:
Loaded image: bazel/image:image
ERROR: /Users/andrew.basson/dev/github/bassco/formatjs/packages/intl-datetimeformat/BUILD:953:13: Action packages/intl-datetimeformat/ubuntu_build_essential_image.tar failed: (Exit 1): process-wrapper failed: error executing command 
  (cd /private/var/tmp/_bazel_andrew.basson/2cd4575d98833912328453bc05fea064/sandbox/processwrapper-sandbox/56/execroot/formatjs && \
  exec env - \
    PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin \
    TMPDIR=/var/folders/vh/wn06p_z927q5m27fdvm30fsnf3km0t/T/ \
  /var/tmp/_bazel_andrew.basson/install/20ec3ea603998b5c8b8d9768fc5987cd/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/private/var/tmp/_bazel_andrew.basson/2cd4575d98833912328453bc05fea064/sandbox/processwrapper-sandbox/56/stats.out' bazel-out/darwin-opt-exec-2B5CBBC6-ST-625e526ca8a8/bin/external/io_bazel_rules_docker/docker/util/config_stripper '--in_tar_path=bazel-out/darwin-fastbuild-ST-4a519fd6d3e4/bin/packages/intl-datetimeformat/ubuntu_build_essential_image.tar.unstripped' '--out_tar_path=bazel-out/darwin-fastbuild-ST-4a519fd6d3e4/bin/packages/intl-datetimeformat/ubuntu_build_essential_image.tar')
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_andrew.basson/2cd4575d98833912328453bc05fea064/sandbox/processwrapper-sandbox/56/execroot/formatjs/bazel-out/darwin-opt-exec-2B5CBBC6-ST-625e526ca8a8/bin/external/io_bazel_rules_docker/docker/util/config_stripper.runfiles/io_bazel_rules_docker/docker/util/config_stripper.py", line 248, in <module>
    sys.exit(main())
             ^^^^^^
  File "/private/var/tmp/_bazel_andrew.basson/2cd4575d98833912328453bc05fea064/sandbox/processwrapper-sandbox/56/execroot/formatjs/bazel-out/darwin-opt-exec-2B5CBBC6-ST-625e526ca8a8/bin/external/io_bazel_rules_docker/docker/util/config_stripper.runfiles/io_bazel_rules_docker/docker/util/config_stripper.py", line 47, in main
    return strip_tar(args.in_tar_path, args.out_tar_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_andrew.basson/2cd4575d98833912328453bc05fea064/sandbox/processwrapper-sandbox/56/execroot/formatjs/bazel-out/darwin-opt-exec-2B5CBBC6-ST-625e526ca8a8/bin/external/io_bazel_rules_docker/docker/util/config_stripper.runfiles/io_bazel_rules_docker/docker/util/config_stripper.py", line 73, in strip_tar
    (new_layer_name, new_diff_id) = strip_layer(os.path.join(tempdir, layer))
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_andrew.basson/2cd4575d98833912328453bc05fea064/sandbox/processwrapper-sandbox/56/execroot/formatjs/bazel-out/darwin-opt-exec-2B5CBBC6-ST-625e526ca8a8/bin/external/io_bazel_rules_docker/docker/util/config_stripper.runfiles/io_bazel_rules_docker/docker/util/config_stripper.py", line 169, in strip_layer
    with tarfile.open(name=path, mode='r') as it:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/tarfile.py", line 1804, in open
    return func(name, "r", fileobj, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/tarfile.py", line 1870, in gzopen
    fileobj = GzipFile(name, mode + "b", compresslevel, fileobj)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/gzip.py", line 174, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/vh/wn06p_z927q5m27fdvm30fsnf3km0t/T/tmpj0fv1f70/blobs/sha256/24b49c9bd61e80e95c99301f18eeecdb7ec349f6e64ea11fd03a3f78ca0ffd02'
Target //packages/intl-datetimeformat:generated_tz_data failed to build
INFO: Elapsed time: 61.956s, Critical Path: 55.70s
INFO: 10 processes: 4 internal, 6 processwrapper-sandbox.
ERROR: Build failed. Not running target
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/42c21fcd-5f66-43fa-8962-02a93f9c6d8e
FAILED: Build did NOT complete successfully
```

Issue Number: N/A


## What is the new behavior?

The updated config_stripper.py takes the multiple file in a single folder into account and corrects the path of the config blob too.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

The new saved image has the following layout

```
unstripped-image-content
├── blobs
│   └── sha256
│       ├── 1ecf1645c844e16abff7d8d100049c428c12203678c1588bad75a08842cc3190
│       ├── 1f2f4f3a1399d1db179fe62b8b2b87f2f433fe70a006074cb62210adf4d66c7c
│       ├── 24b49c9bd61e80e95c99301f18eeecdb7ec349f6e64ea11fd03a3f78ca0ffd02
│       ├── 3ea479cf97e7c1d7a4fe4c81f61b409bb43c6923b36ee9001173f0cdaab0b000
│       ├── 3f1df58d1a4767b78ed0a9abcaffe937e8baf50beb59f8c5348f6f155d8644d0
│       └── f84e9e2d12dfcf097cdb0216fb65e2e2866ff9f4723442eecedfddb520e5a847
├── index.json
├── manifest.json
├── oci-layout
└── repositories
```

which produces 

```
stripped-image-content
├── blobs
│   ├── sha256
│   │   └── sha256:b91c395382799c59abff627b93d1f9d42f574ad4f214e174f7d90e1929a67633
│   ├── sha256:518da94611f88d4fb1ba467019e0eafd0ae82717ac5699643a1f7d942568baaa
│   └── sha256:6898f4c370e1e5635dde8890ef1b7b24acbc6ea4f1fe9987e0445f8a34250c8f
├── manifest.json
└── repositories
```